### PR TITLE
Add AdMob app-ads.txt (#1)

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1318352439976892, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- AdMob 광고 인벤토리 인증을 위한 `app-ads.txt` 파일 추가
- Google publisher ID: `pub-1318352439976892`

Closes #1

## Test plan
- [ ] GitHub Pages 배포 후 `https://yonahalab.com/app-ads.txt` 접근 확인
- [ ] 파일 내용이 AdMob 대시보드의 app-ads.txt 내용과 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)